### PR TITLE
Adds an optional command line paramater to specify the configuration

### DIFF
--- a/bin/s3-upload.js
+++ b/bin/s3-upload.js
@@ -5,9 +5,9 @@ var path = require('path');
 var runner = new ConfigRunner();
 
 
-var configPath = path.resolve('./aws-upload.conf.js');
+var configPath = process.argv[2] || './aws-upload.conf.js';
 
-var config = require(configPath);
+var config = require(path.resolve(configPath));
 
 runner.setConfig(config);
 


### PR DESCRIPTION
For QA purposes it's useful to be able to push a release to both staging
and production buckets. This change allows you to specify the config file
that s3-upload uses in order be able to push the same files to both a staging
and production bucket:

`s3-upload staging-upload.conf.js`
`s3-upload production-upload.conf.js`