### PR TITLE
Set default content-type to 'text/html'

### DIFF
--- a/src/S3ParameterBuilder.js
+++ b/src/S3ParameterBuilder.js
@@ -25,6 +25,7 @@ var createParams = {
         };
     },
     putObject:function(bucketName, key, body, mimeType){
+        mime.default_type = 'text/html';
         mimeType = mimeType || mime.lookup(key);
 
         // console.log(body);


### PR DESCRIPTION
The Mime library defaults to 'application/octet-stream', but for folks
who want extentionless urls served by s3, you have to take the
extention off the filename.

Resolves #7.