### PR TITLE
`config.credentials` should not be mandatory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Have AWS create a new key pair for the user and copy the contents into a `aws-cr
 }
 ```
 
+**note**: As AWS SDK's documentation points out, you could also set those as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables 
+
 User Permissions
 ----------------
 

--- a/src/ConfigRunner.js
+++ b/src/ConfigRunner.js
@@ -17,7 +17,7 @@ return function ConfigRunner(){
 
     this.run = function(){
 
-        AWS.config.loadFromPath(config.credentials);
+        config.credentials && AWS.config.loadFromPath(config.credentials);
 
         var s3 = new S3();
         var s3Wrapper = new S3PromiseWrapper(s3);


### PR DESCRIPTION
When using a continuous integration solution for example you do not want to have to export your credentials to your repo.

As specified in the [AWS documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html) :

```
Credentials from Environment Variables

By default, the SDK will automatically detect AWS credentials set in your environment and use them for requests. This means that if you properly set your environment variables, you do not need to manage credentials in your application at all.

The keys that the SDK looks for are as follows:

AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN (optional)
Alternately, the SDK can accept the AMAZON_ prefix instead:

AMAZON_ACCESS_KEY_ID, AMAZON_SECRET_ACCESS_KEY, AMAZON_SESSION_TOKEN (optional)
```

AWS SDK's will solely resolve this, therefore making this file non-mandatory.

Tested working on my stack.