### PR TITLE
Fix local require incorrect path

### DIFF
--- a/bin/s3-upload.js
+++ b/bin/s3-upload.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var ConfigRunner = require('../src/ConfigRunner.js');
+var ConfigRunner = require('s3-upload/src/ConfigRunner.js');
 var path = require('path');
 
 var runner = new ConfigRunner();


### PR DESCRIPTION
If run from an npm script (e.g. "npm run deploy") using a locally installed dependency, the executable JS file is symlinked into `<project>/node_modules/.bin` and the relative require will fail. This ensures it will work in all contexts.
